### PR TITLE
Revert "Set client_max_body_size: 20m;"

### DIFF
--- a/src/assets/nginx.yaml
+++ b/src/assets/nginx.yaml
@@ -7,7 +7,6 @@ files:
           proxy_buffer_size 128k;
           proxy_buffers 4 256k;
           proxy_busy_buffers_size 256k;
-          client_max_body_size: 20m;
 
           upstream nodejs {
             server 127.0.0.1:8081;
@@ -83,7 +82,7 @@ files:
               proxy_set_header Upgrade $http_upgrade;
               proxy_set_header Connection "upgrade";
             }
-
+    
             gzip on;
             gzip_comp_level 4;
             gzip_types text/html text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;


### PR DESCRIPTION
Reverts hiveteams/mup-aws-beanstalk#3 because it was throwing this error in nginx error logs:

2020/09/03 21:12:46 [emerg] 4859#0: unknown directive "client_max_body_size:" in /etc/nginx/conf.d/proxy.conf:4