### PR TITLE
Support for custom ebextensions config files

### DIFF
--- a/src/prepare-bundle.js
+++ b/src/prepare-bundle.js
@@ -18,7 +18,8 @@ export function injectFiles(api, name, version, appConfig) {
     forceSSL,
     gracefulShutdown,
     buildOptions,
-    longEnvVars
+    longEnvVars,
+    path
   } = appConfig;
   const bundlePath = buildOptions.buildLocation;
   const {
@@ -80,6 +81,17 @@ export function injectFiles(api, name, version, appConfig) {
   sourcePath = api.resolvePath(__dirname, './assets/health-check.js');
   destPath = api.resolvePath(bundlePath, 'bundle/health-check.js');
   copy(sourcePath, destPath);
+
+  const customConfigPath = api.resolvePath(api.getBasePath(), `${path}/.ebextensions`);
+  const customConfig = fs.existsSync(customConfigPath);
+  if (customConfig) {
+    console.log('  Copying files from project .ebextensions folder');
+    fs.readdirSync(customConfigPath).forEach((file) => {
+      sourcePath = api.resolvePath(customConfigPath, file);
+      destPath = api.resolvePath(bundlePath, `bundle/.ebextensions/${file}`);
+      copy(sourcePath, destPath);
+    });
+  }
 }
 
 export function archiveApp(buildLocation, api) {


### PR DESCRIPTION
From https://github.com/zodern/mup-aws-beanstalk/pull/72

Adds support for copying config files from a top-level `.ebextensions`directory.