### PR TITLE
fix/nginx-config-for-Webviewer

### DIFF
--- a/src/assets/nginx-server.conf
+++ b/src/assets/nginx-server.conf
@@ -21,6 +21,22 @@ location / {
   <% } %>
 }
 
+# Redirects traffic to meteor app.
+# Used to skip font interseptors below (eot|ttf|woff) for meteor proxy apis
+# https://github.com/zodern/mup-aws-beanstalk/issues/120
+# https://github.com/hiveteams/Hive/pull/17446/files#diff-7f0ccf4eb0551b9491b1656a21d28c0e93fbfa12df9ad7d416c7ea36ba2ef27cR6
+location ~ ^(/proofing-s3-proxy-Webviewer) {
+  proxy_pass http://127.0.0.1:3000 ;
+  proxy_http_version 1.1           ;
+
+  proxy_set_header Connection $connection_upgrade             ;
+  proxy_set_header Upgrade $http_upgrade                      ;
+  proxy_set_header Host $host                                 ;
+  proxy_set_header X-Real-IP $remote_addr                     ;
+  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for ;
+
+  add_header Strict-Transport-Security "max-age=31536000; includeSubDomains;";
+}
 
 location ~* /packages/.+\.(eot|ttf|woff)$ {
   root /var/app/current/programs/web.browser;

--- a/src/assets/nginx-server.conf
+++ b/src/assets/nginx-server.conf
@@ -26,16 +26,18 @@ location / {
 # https://github.com/zodern/mup-aws-beanstalk/issues/120
 # https://github.com/hiveteams/Hive/pull/17446/files#diff-7f0ccf4eb0551b9491b1656a21d28c0e93fbfa12df9ad7d416c7ea36ba2ef27cR6
 location ~ ^(/proofing-s3-proxy-Webviewer) {
-  proxy_pass http://127.0.0.1:3000 ;
-  proxy_http_version 1.1           ;
+  proxy_pass          http://127.0.0.1:8081;
+  proxy_http_version  1.1;
 
-  proxy_set_header Connection $connection_upgrade             ;
-  proxy_set_header Upgrade $http_upgrade                      ;
-  proxy_set_header Host $host                                 ;
-  proxy_set_header X-Real-IP $remote_addr                     ;
-  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for ;
+  proxy_set_header    Connection          $connection_upgrade;
+  proxy_set_header    Upgrade             $http_upgrade;
+  proxy_set_header    Host                $host;
+  proxy_set_header    X-Real-IP           $remote_addr;
+  proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for;
 
+  <% if(forceSSL) { %>
   add_header Strict-Transport-Security "max-age=31536000; includeSubDomains;";
+  <% } %>
 }
 
 location ~* /packages/.+\.(eot|ttf|woff)$ {

--- a/src/assets/nginx.conf
+++ b/src/assets/nginx.conf
@@ -35,23 +35,6 @@ server {
   }
   <% } %>
 
-  # Redirects traffic to meteor app.
-  # Used to skip font interseptors below (eot|ttf|woff) for meteor proxy apis
-  # https://github.com/zodern/mup-aws-beanstalk/issues/120
-  # https://github.com/hiveteams/Hive/pull/17446/files#diff-7f0ccf4eb0551b9491b1656a21d28c0e93fbfa12df9ad7d416c7ea36ba2ef27cR6
-  location ~ ^(/proofing-s3-proxy-Webviewer) {
-      proxy_pass http://127.0.0.1:3000 ;
-      proxy_http_version 1.1           ;
-
-      proxy_set_header Connection $connection_upgrade             ;
-      proxy_set_header Upgrade $http_upgrade                      ;
-      proxy_set_header Host $host                                 ;
-      proxy_set_header X-Real-IP $remote_addr                     ;
-      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for ;
-
-      add_header Strict-Transport-Security "max-age=31536000; includeSubDomains;";
-  }
-
   location ~* /packages/.+\.(eot|ttf|woff)$ {
     root /var/app/current/programs/web.browser;
     access_log off;

--- a/src/assets/nginx.conf
+++ b/src/assets/nginx.conf
@@ -35,6 +35,23 @@ server {
   }
   <% } %>
 
+  # Redirects traffic to meteor app.
+  # Used to skip font interseptors below (eot|ttf|woff) for meteor proxy apis
+  # https://github.com/zodern/mup-aws-beanstalk/issues/120
+  # https://github.com/hiveteams/Hive/pull/17446/files#diff-7f0ccf4eb0551b9491b1656a21d28c0e93fbfa12df9ad7d416c7ea36ba2ef27cR6
+  location ~ ^(/proofing-s3-proxy-Webviewer) {
+      proxy_pass http://127.0.0.1:3000 ;
+      proxy_http_version 1.1           ;
+
+      proxy_set_header Connection $connection_upgrade             ;
+      proxy_set_header Upgrade $http_upgrade                      ;
+      proxy_set_header Host $host                                 ;
+      proxy_set_header X-Real-IP $remote_addr                     ;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for ;
+
+      add_header Strict-Transport-Security "max-age=31536000; includeSubDomains;";
+  }
+
   location ~* /packages/.+\.(eot|ttf|woff)$ {
     root /var/app/current/programs/web.browser;
     access_log off;


### PR DESCRIPTION
- https://beta.hive.com/workspace/7driFnaZjDQZndHqs?actionId=XXoJxnsyqGWbp6bQa

- fonts dir does no available for downloading by proofing-s3-proxy-Webviewer https://beta.hive.com/proofing-s3-proxy-Webviewer/ui/assets/fonts/GreatVibes-Regular.woff This request hendeled by Nginx proxy, not aws s3!

- we have nginx config for our mup deployment server https://github.com/hiveteams/mup-aws-beanstalk/blob/master/src/assets/nginx-server.conf#L35 https://github.com/hiveteams/mup-aws-beanstalk/blob/master/src/assets/nginx.conf#L48 This locations handle any request with file extensions eot, ttf, woff. So meteor handler /proofing-s3-proxy-Webviewer can't handel request https://beta.hive.com/proofing-s3-proxy-Webviewer/ui/assets/fonts/GreatVibes-Regular.woff  because it will be rewrited to file syste folder  var/app/current/programs/web.browser/app

---

Add new location rules for requests that starts by /proofing-s3-proxy-Webviewer
- pros: will affect only Webviewer requests
- cons: growing of code code complexity. Meteor route will be depended on magic proxy config. If we will update nginx, why we should use meteor proxy? We can implement this proxy on nginx level without meteor routing