### PR TITLE
Revert "fix/nginx-config-for-Webviewer"

### DIFF
--- a/src/assets/nginx-server.conf
+++ b/src/assets/nginx-server.conf
@@ -21,24 +21,6 @@ location / {
   <% } %>
 }
 
-# Redirects traffic to meteor app.
-# Used to skip font interseptors below (eot|ttf|woff) for meteor proxy apis
-# https://github.com/zodern/mup-aws-beanstalk/issues/120
-# https://github.com/hiveteams/Hive/pull/17446/files#diff-7f0ccf4eb0551b9491b1656a21d28c0e93fbfa12df9ad7d416c7ea36ba2ef27cR6
-location ~ ^(/proofing-s3-proxy-Webviewer) {
-  proxy_pass          http://127.0.0.1:8081;
-  proxy_http_version  1.1;
-
-  proxy_set_header    Connection          $connection_upgrade;
-  proxy_set_header    Upgrade             $http_upgrade;
-  proxy_set_header    Host                $host;
-  proxy_set_header    X-Real-IP           $remote_addr;
-  proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for;
-
-  <% if(forceSSL) { %>
-  add_header Strict-Transport-Security "max-age=31536000; includeSubDomains;";
-  <% } %>
-}
 
 location ~* /packages/.+\.(eot|ttf|woff)$ {
   root /var/app/current/programs/web.browser;


### PR DESCRIPTION
### Hive: https://github.com/hiveteams/Hive/pull/17738

Reverts hiveteams/mup-aws-beanstalk#14

# Reason:
- customization of nginx config files should be implemented in Hive repo https://github.com/hiveteams/Hive/blob/master/.platform/nginx/conf.d. `.platform` used to exclude human factor from deployment scripts. this configs will be injected in mup server configs
- created pr that will add nginx config for `/proofing-s3-proxy-Webviewer` location https://github.com/hiveteams/Hive/pull/17738/files